### PR TITLE
HUB-18751 Reduce log storage threshold to 14 days

### DIFF
--- a/deleteLogs.sh
+++ b/deleteLogs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 while true; do
-NUM_DAYS=${DAYS_TO_KEEP_LOGS:-30}
+NUM_DAYS=${DAYS_TO_KEEP_LOGS:-14}
 echo "Files deleted on $(date +%x_%r):" >> /var/log/deleteLogs.log
 find /var/lib/logstash/data/ -mindepth 2 -type f -mtime +$NUM_DAYS >> /var/log/deleteLogs.log
 find /var/lib/logstash/data/ -mindepth 2 -type f -mtime +$NUM_DAYS -delete


### PR DESCRIPTION
Reduces the default amount of time that logs are kept around for to the past 14 days, from 30.